### PR TITLE
feat: source shell config instead of symlink

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ CONF_DIR=${SCRIPT_ROOT}/conf
 BACKUP_DIR=${HOME}/dotfiles_backup
 
 DOTFILES=(
-.vimrc .config/nvim .config/aquaproj-aqua .bash_profile .bashrc .profile .zshrc .zshenv .zsh .gitignore_global
+.vimrc .config/nvim .config/aquaproj-aqua .zsh .gitignore_global
 )
 
 mkdir -p "${HOME}/.config"
@@ -21,6 +21,35 @@ do
 	fi
 
 	ln -vnsf "${CONF_DIR}/${f}" "${HOME}/${f}"
+done
+
+SHELL_RCS=(
+.bash_profile .bashrc .profile .zshenv .zshrc
+)
+
+for f in "${SHELL_RCS[@]}"
+do
+	echo "Creating shell config file ${f} ..."
+
+	if [[ -f ${HOME}/${f} ]]; then
+		if grep -q '^# MANAGED BLOCK BY DOTFILE$' "${HOME}/${f}"; then
+			continue
+		fi
+
+		if [[ ! -L ${HOME}/${f} ]]; then
+			echo "${f} already exists. Back it up to ${BACKUP_DIR}/${f}"
+			mkdir -p "$(dirname "${BACKUP_DIR}/${f}")"
+			mv "${HOME}/${f}" "${BACKUP_DIR}/${f}"
+		else
+			unlink "${HOME}/${f}"
+		fi
+	fi
+
+	cat <<-EOS >>"${HOME}/${f}"
+		# MANAGED BLOCK BY DOTFILE
+		test -f "${CONF_DIR}/${f}" && . "${CONF_DIR}/${f}"
+		# END OF MANAGED BLOCK BY DOTFILE
+		EOS
 done
 
 echo "Setting .gitignore_global"


### PR DESCRIPTION
Many CLI tools automatically append initialization snippets into shell configuration files like .bashrc or .zshrc, causing unstaged changes on this dotfiles Git repository.
In this PR, instead of creating symbolic link to the dotfiles directory, shell rc files are created which `source` the shell configs in the dotfiles directory.
This prevents CLI tools from polluting dotfile's shell configs.
