### PR TITLE
feat(zsh): enable Powerlevel10k instant prompt

### DIFF
--- a/conf/.zsh/p10k.zsh
+++ b/conf/.zsh/p10k.zsh
@@ -1685,7 +1685,7 @@
   #   - verbose: Enable instant prompt and print a warning when detecting console output during
   #              zsh initialization. Choose this if you've never tried instant prompt, haven't
   #              seen the warning, or if you are unsure what this all means.
-  typeset -g POWERLEVEL9K_INSTANT_PROMPT=off
+  typeset -g POWERLEVEL9K_INSTANT_PROMPT=verbose
 
   # Hot reload allows you to change POWERLEVEL9K options after Powerlevel10k has been initialized.
   # For example, you can type POWERLEVEL9K_BACKGROUND=red and see your prompt turn red. Hot reload

--- a/conf/.zshrc
+++ b/conf/.zshrc
@@ -2,6 +2,11 @@
 
 umask 022
 
+# Enable Powerlevel10k instant prompt. Should stay close to the top of ~/.zshrc.
+if [[ -r "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]; then
+  source "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh"
+fi
+
 if [[ -f ~/.no_zinit ]]; then
 	:
 else


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enabled verbose mode for the instant prompt feature in Powerlevel10k.
	- Added a mechanism to source a cache file for the instant prompt during Zsh startup.

- **Bug Fixes**
	- Improved initialization behavior of the prompt by providing additional output during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->