### PR TITLE
fix(nvim): remove XTerm paste mode configuration

### DIFF
--- a/conf/.config/nvim/init.vim
+++ b/conf/.config/nvim/init.vim
@@ -47,20 +47,6 @@ set updatetime=300
 highlight FullWidthSpace ctermbg=LightCyan
 match FullWidthSpace /　/
 
-" Paste
-if &term =~ 'xterm'
-  let &t_SI .= "\e[?2004h"
-  let &t_EI .= "\e[?2004l"
-  let &pastetoggle = "\e[201~"
-
-  function XTermPasteBegin(ret)
-    set paste
-    return a:ret
-  endfunction
-
-  inoremap <special> <expr> <Esc>[200~ XTermPasteBegin('')
-endif
-
 " Enable mouse
 if has('mouse')
   set mouse=a


### PR DESCRIPTION
## Summary
- Remove obsolete XTerm paste mode handling from nvim configuration
- Clean up configuration by removing code that is no longer needed in modern terminal environments

## Test plan
- [x] Verify nvim starts without errors
- [x] Confirm paste functionality still works in terminal
- [x] Test with different terminal emulators

## Reason

Current config is invalid on the latest nvim version (NVIM v0.11.3).
Removing the mouse handling fixes the problem.

```text
Error detected while processing /home/****/dotfiles/conf/.config/nvim/init.vim:
line   54:
E519: Option not supported
Press ENTER or type command to continue
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed all configurations related to paste mode handling in xterm terminals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->