### PR TITLE
docs: add migration guide and reorganize documentation

### DIFF
--- a/.chezmoiignore.tmpl
+++ b/.chezmoiignore.tmpl
@@ -2,3 +2,4 @@ install.sh
 LICENSE.txt
 README.md
 renovate.json
+docs/

--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ cd ~/dotfiles
 ./install.sh
 ```
 
-## Licence
+## Migration
+
+If you're upgrading from the previous version of this dotfiles repository, see [Migration Guide](docs/MIGRATION.md).
+
+## License
 
 The code is available under the MIT license.
 See the [LICENSE.txt](LICENSE.txt) file for more information.

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,0 +1,44 @@
+# Migration from Previous Dotfiles Version
+
+If you're upgrading from the previous version of this dotfiles repository (before chezmoi migration):
+
+## 1. Install Chezmoi and Initialize
+
+```sh
+sh -c "$(curl -fsLS get.chezmoi.io)" -- init pinelibg
+```
+
+## 2. Review Changes
+
+Check what files will be managed and what changes will be made:
+
+```sh
+chezmoi diff
+```
+
+## 3. Apply the Configuration
+
+If the changes look good, apply them:
+
+```sh
+chezmoi apply
+```
+
+## 4. Verify Everything Works
+
+Test that your shell and tools are working correctly with the new setup.
+
+## 5. Remove Old Installation
+
+Once you've confirmed the new setup works:
+
+```sh
+# Remove the old dotfiles repository
+rm -rf ~/dotfiles
+```
+
+## Key Changes
+
+- Dotfiles are now managed by chezmoi instead of manual symlinks
+- Use `chezmoi update` to pull and apply the latest changes
+- Customize files through `chezmoi edit` rather than editing the repository directly


### PR DESCRIPTION
## Summary
- Add comprehensive migration guide for transitioning from manual dotfile management to chezmoi
- Reorganize documentation structure to improve clarity and navigation
- Include step-by-step instructions for existing users

## Test plan
- [x] Verify migration guide instructions are accurate
- [x] Test that all links in documentation work correctly
- [x] Ensure documentation structure is logical and easy to follow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Migration Guide to help users transition from the previous dotfiles setup to the new chezmoi-managed configuration.
  * Updated the README with a new "Migration" section and corrected the "License" heading.
* **Chores**
  * Configured the system to ignore the documentation directory during chezmoi operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->