### PR TITLE
fix(chezmoi): use full path for template execution in modify_shellfile

### DIFF
--- a/.chezmoitemplates/modify_shellfile
+++ b/.chezmoitemplates/modify_shellfile
@@ -4,7 +4,7 @@ set -eu -o pipefail
 
 function insert_template() {
   echo "${START_BLOCK}"
-  chezmoi execute-template <.chezmoitemplates/{{ . }}
+  chezmoi execute-template <"${CHEZMOI_SOURCE_DIR}/.chezmoitemplates/{{ . }}"
   echo "${END_BLOCK}"
 }
 


### PR DESCRIPTION
## Summary
- Fix template path resolution in modify_shellfile script
- Use CHEZMOI_SOURCE_DIR variable to construct full path to templates
- Ensures script works correctly regardless of current working directory

## Test plan
- [x] Verify modify_shellfile script executes templates correctly from any directory
- [x] Test that template execution uses the correct source path
- [x] Confirm no regression in existing functionality