### PR TITLE
refactor: migrate shell file modification from template to script

### DIFF
--- a/.chezmoiignore.tmpl
+++ b/.chezmoiignore.tmpl
@@ -3,3 +3,4 @@ LICENSE.txt
 README.md
 renovate.json
 docs/
+scripts/

--- a/modify_dot_bash_profile.tmpl
+++ b/modify_dot_bash_profile.tmpl
@@ -1,1 +1,9 @@
-{{- template "modify_shellfile" "dot_bash_profile" -}}
+#!/bin/bash
+
+function print_template() {
+  cat <<'EOF'
+{{ template "dot_bash_profile" -}}
+EOF
+}
+
+. "${CHEZMOI_SOURCE_DIR}/scripts/modify_shellfile.sh"

--- a/modify_dot_bashrc.tmpl
+++ b/modify_dot_bashrc.tmpl
@@ -1,1 +1,9 @@
-{{- template "modify_shellfile" "dot_bashrc" -}}
+#!/bin/bash
+
+function print_template() {
+  cat <<'EOF'
+{{ template "dot_bashrc" -}}
+EOF
+}
+
+. "${CHEZMOI_SOURCE_DIR}/scripts/modify_shellfile.sh"

--- a/modify_dot_profile.tmpl
+++ b/modify_dot_profile.tmpl
@@ -1,1 +1,9 @@
-{{- template "modify_shellfile" "dot_profile" -}}
+#!/bin/bash
+
+function print_template() {
+  cat <<'EOF'
+{{ template "dot_profile" -}}
+EOF
+}
+
+. "${CHEZMOI_SOURCE_DIR}/scripts/modify_shellfile.sh"

--- a/modify_dot_zshenv.tmpl
+++ b/modify_dot_zshenv.tmpl
@@ -1,1 +1,9 @@
-{{- template "modify_shellfile" "dot_zshenv" -}}
+#!/bin/bash
+
+function print_template() {
+  cat <<'EOF'
+{{ template "dot_zshenv" -}}
+EOF
+}
+
+. "${CHEZMOI_SOURCE_DIR}/scripts/modify_shellfile.sh"

--- a/modify_dot_zshrc.tmpl
+++ b/modify_dot_zshrc.tmpl
@@ -1,1 +1,9 @@
-{{- template "modify_shellfile" "dot_zshrc" -}}
+#!/bin/bash
+
+function print_template() {
+  cat <<'EOF'
+{{ template "dot_zshrc" -}}
+EOF
+}
+
+. "${CHEZMOI_SOURCE_DIR}/scripts/modify_shellfile.sh"

--- a/scripts/modify_shellfile.sh
+++ b/scripts/modify_shellfile.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 
-set -eu -o pipefail
+if ! command -v print_template &> /dev/null; then
+  echo "Error: print_template command not found. Please ensure that the template function is defined." >&2
+  exit 1
+fi
 
-function insert_template() {
-  echo "${START_BLOCK}"
-  chezmoi execute-template <"${CHEZMOI_SOURCE_DIR}/.chezmoitemplates/{{ . }}"
-  echo "${END_BLOCK}"
-}
+set -eu -o pipefail
 
 # Create temporary file to store input
 tempfile="$(mktemp)"
@@ -20,7 +19,9 @@ END_BLOCK="# END OF MANAGED BLOCK BY DOTFILE"
 # If the original file does not contain the managed block, insert it at the beginning
 if ! (grep -q "${START_BLOCK}" "${tempfile}" && grep -q "${END_BLOCK}" "${tempfile}"); then
   # Output managed block
-  insert_template
+  echo "${START_BLOCK}"
+  print_template
+  echo "${END_BLOCK}"
 
   # Output the entire content of the file
   cat "${tempfile}"
@@ -29,7 +30,9 @@ else
   sed "/${START_BLOCK}/q" "${tempfile}" | sed '$d'
 
   # Output managed block
-  insert_template
+  echo "${START_BLOCK}"
+  print_template
+  echo "${END_BLOCK}"
 
   # Output content after managed block
   sed -n "/${END_BLOCK}/,\$p" "${tempfile}" | sed "1d"


### PR DESCRIPTION
## Summary
- Moved `modify_shellfile` from `.chezmoitemplates` to `scripts` directory for better maintainability
- Updated all `modify_dot_*` files to use the new script-based approach instead of template calls
- Replaced template-based implementation with function-based approach using `print_template()` function
- Centralized shell modification logic in a single script file

## Changes
- **Moved**: `.chezmoitemplates/modify_shellfile` → `scripts/modify_shellfile.sh`
- **Updated**: All `modify_dot_*` template files to use new script approach
- **Improved**: Code maintainability by separating template logic from shell modification logic

## Test plan
- [ ] Verify chezmoi templates still render correctly
- [ ] Test shell file modification functionality with different dot files
- [ ] Ensure managed block insertion/replacement works as expected
- [ ] Validate that all shell profiles (.bashrc, .bash_profile, .profile, .zshrc, .zshenv) work correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated shell configuration modification scripts to use standalone Bash scripts with improved structure and external script sourcing.
  * Added functions to print template content within these scripts for better flexibility.

* **Chores**
  * Updated ignore settings to exclude the scripts directory from management.
  * Improved error handling and structure in the shellfile modification script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->