### PR TITLE
refactor: improve starship newline configuration

### DIFF
--- a/dot_config/starship.toml
+++ b/dot_config/starship.toml
@@ -2,6 +2,8 @@
 # Documentation: https://starship.rs/config/
 "$schema" = 'https://starship.rs/config-schema.json'
 
+add_newline = false
+
 # Based on Pure Prompt preset
 
 format = """
@@ -50,6 +52,3 @@ style = "yellow"
 [python]
 format = "[$virtualenv]($style) "
 style = "bright-black"
-
-[line_break]
-disabled = true


### PR DESCRIPTION
## Summary
- Replace `line_break.disabled` with `add_newline` setting for cleaner configuration
- Improves consistency with starship configuration best practices

## Test plan
- [x] Verify starship prompt renders correctly without extra newlines
- [x] Confirm configuration follows starship documentation standards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Starship prompt configuration to disable automatic newline after the prompt.
  * Removed the disabled line break section from the configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->