### PR TITLE
docs: improve README installation instructions with multiple methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,27 @@ This repository contains my personal configuration files for shells and editors.
 
 ## Install
 
-Install [chezmoi](https://www.chezmoi.io/) and dotfiles with the single command:
+### Quick Install
+
+Install dotfiles with a single command:
 
 ```sh
-sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply pinelibg
+sh -c "$(curl -fsLS get.chezmoi.io)" -- -b "${HOME}/.local/bin" init --apply pinelibg
 ```
 
-Or you can run the following commands in the terminal.
+### Alternative Methods
+
+#### Using existing chezmoi
+
+If you already have chezmoi installed ([Install chezmoi](https://www.chezmoi.io/install/)):
+
+```sh
+chezmoi init --apply pinelibg
+```
+
+#### Manual setup
+
+Clone and run the setup script:
 
 ```sh
 git clone https://github.com/pinelibg/dotfiles.git ~/dotfiles


### PR DESCRIPTION
## Summary
- Add quick install section with single command option
- Reorganize existing installation methods for better user experience
- Provide alternative methods for users with different preferences

## Test plan
- [x] Verify README renders correctly on GitHub
- [x] Test installation commands work as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Revamped Install section into “Quick Install” with a single curl command that installs chezmoi to ~/.local/bin and applies dotfiles.
  * Simplified guidance for users with chezmoi already installed: run chezmoi init --apply pinelibg.
  * Expanded Manual setup with steps to clone the repo, cd into the directory, and run the install script.
  * Added an “Alternative Methods” section to present multiple installation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->