### PR TITLE
feat(nvim): add dial.nvim plugin for extended increment/decrement

### DIFF
--- a/dot_config/nvim/dein.toml
+++ b/dot_config/nvim/dein.toml
@@ -242,3 +242,65 @@ repo = 'tpope/vim-surround'
 # gc: comment out target (in visual mode)
 [[plugins]]
 repo = 'tpope/vim-commentary'
+
+# Extended increment/decrement (toggling true⇆false &&⇆||)
+# https://github.com/monaqa/dial.nvim
+# Ctrl-a/x: increment/decrement
+[[plugins]]
+repo = 'monaqa/dial.nvim'
+lua_source = '''
+    vim.keymap.set("n", "<C-a>", function()
+        require("dial.map").manipulate("increment", "normal")
+    end)
+    vim.keymap.set("n", "<C-x>", function()
+        require("dial.map").manipulate("decrement", "normal")
+    end)
+    vim.keymap.set("n", "g<C-a>", function()
+        require("dial.map").manipulate("increment", "gnormal")
+    end)
+    vim.keymap.set("n", "g<C-x>", function()
+        require("dial.map").manipulate("decrement", "gnormal")
+    end)
+    vim.keymap.set("x", "<C-a>", function()
+        require("dial.map").manipulate("increment", "visual")
+    end)
+    vim.keymap.set("x", "<C-x>", function()
+        require("dial.map").manipulate("decrement", "visual")
+    end)
+    vim.keymap.set("x", "g<C-a>", function()
+        require("dial.map").manipulate("increment", "gvisual")
+    end)
+    vim.keymap.set("x", "g<C-x>", function()
+        require("dial.map").manipulate("decrement", "gvisual")
+    end)
+
+    local augend = require("dial.augend")
+      require("dial.config").augends:register_group{
+        default = {
+          augend.integer.alias.decimal_int,
+          augend.integer.alias.hex,
+          augend.date.alias["%Y/%m/%d"],
+          augend.date.alias["%Y-%m-%d"],
+          augend.date.alias["%m/%d"],
+          augend.date.alias["%H:%M"],
+          augend.constant.alias.ja_weekday_full,
+          augend.constant.alias.bool,
+          augend.constant.new{
+            elements = {"True", "False"},
+            word = true,
+            cyclic = true,
+          },
+          augend.semver.alias.semver,
+          augend.constant.new{
+            elements = {"&&", "||"},
+            word = false,
+            cyclic = true,
+          },
+          augend.constant.new{
+            elements = {"and", "or"},
+            word = true,
+            cyclic = true,
+          },
+        }
+      }
+'''


### PR DESCRIPTION
## Summary

• Add dial.nvim plugin for enhanced increment/decrement functionality
• Configure boolean toggling (true⇆false) and logical operators (&&⇆||, and⇆or)
• Add support for dates, semver, and custom keymaps for normal/visual modes

## Test plan

- [x] Verify plugin loads correctly in Neovim
- [x] Test Ctrl-a/x increment/decrement on numbers
- [x] Test boolean toggling functionality
- [x] Test logical operator toggling
- [x] Verify keymaps work in both normal and visual modes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enhanced increment/decrement capabilities in Neovim for numbers, hex, dates, times, weekdays, booleans, True/False, SemVer, and logical operators/words.
  * New key mappings:
    - Normal: Ctrl-A (increment), Ctrl-X (decrement)
    - Normal with g-prefix: g Ctrl-A, g Ctrl-X (linewise-aware)
    - Visual: Ctrl-A, Ctrl-X (operate on selection)
    - Visual with g-prefix: g Ctrl-A, g Ctrl-X (block-aware)
  * Supports cyclic toggling for boolean-like tokens and common logical operators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->