### PR TITLE
feat(zsh): add /snap/bin to PATH in zshenv template

### DIFF
--- a/.chezmoitemplates/dot_zshenv
+++ b/.chezmoitemplates/dot_zshenv
@@ -1,6 +1,7 @@
 typeset -U path
 path=( \
 	/usr/local/bin(N-/) \
+	/snap/bin(N-/) \
 	~/bin(N-/) \
 	~/.local/bin(N-/) \
 	"$path[@]" \


### PR DESCRIPTION
## Summary
- Add `/snap/bin` directory to the PATH configuration in the zshenv template
- Ensures snap-installed applications are available in the shell environment
- Uses conditional inclusion pattern `(N-/)` to only add the directory if it exists

## Changes
- Modified `.chezmoitemplates/dot_zshenv` to include `/snap/bin(N-/)` in the path array
- Maintains consistent formatting and follows existing code patterns
- No breaking changes to existing functionality

## Test plan
- [ ] Verify the zshenv template renders correctly with chezmoi
- [ ] Test that snap binaries are accessible when `/snap/bin` exists
- [ ] Confirm no errors when `/snap/bin` directory doesn't exist
- [ ] Validate that existing PATH functionality remains unchanged