### PR TITLE
feat(nvim): create AppData symlink for nvim config on Windows

### DIFF
--- a/.chezmoiscripts/run_onchange_after_setup-nvim-windows.ps1.tmpl
+++ b/.chezmoiscripts/run_onchange_after_setup-nvim-windows.ps1.tmpl
@@ -1,0 +1,38 @@
+{{- if eq .chezmoi.os "windows" -}}
+
+$nvimConfigSource = Join-Path $env:USERPROFILE ".config\nvim"
+$nvimConfigTarget = Join-Path $env:LOCALAPPDATA "nvim"
+
+$devModeKey = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock"
+$devModeValue = (Get-ItemProperty -Path $devModeKey -ErrorAction SilentlyContinue).AllowDevelopmentWithoutDevLicense
+if ($devModeValue -ne 1) {
+    Write-Error "Developer Mode is not enabled. Enable it in Settings > System > For developers, then re-run chezmoi apply."
+    exit 1
+}
+
+if (-not (Test-Path $nvimConfigSource)) {
+    Write-Error "Neovim config source does not exist: $nvimConfigSource"
+    exit 1
+}
+
+if (Test-Path $nvimConfigTarget) {
+    $item = Get-Item $nvimConfigTarget
+    if ($item.LinkType -eq "SymbolicLink") {
+        $resolvedTarget = $item.Target | ForEach-Object { $_.TrimEnd('\') }
+        $resolvedSource = $nvimConfigSource.TrimEnd('\')
+        if ($resolvedTarget -ieq $resolvedSource) {
+            exit 0
+        }
+    }
+    Write-Warning "Removing existing item at $nvimConfigTarget"
+    Remove-Item $nvimConfigTarget -Force -Recurse
+}
+
+try {
+    New-Item -ItemType SymbolicLink -Path $nvimConfigTarget -Target $nvimConfigSource -ErrorAction Stop | Out-Null
+    Write-Host "Created symlink: $nvimConfigTarget -> $nvimConfigSource"
+} catch {
+    Write-Error "Failed to create symlink: $nvimConfigTarget -> $nvimConfigSource`n$_"
+    exit 1
+}
+{{- end -}}


### PR DESCRIPTION
## Summary

Windows Neovim reads its config from `%LOCALAPPDATA%\nvim`, but chezmoi manages the config at `~/.config/nvim` (XDG standard). This adds a chezmoi `run_onchange_after` script that creates a symbolic link bridging the two paths on `chezmoi apply`.

## Details

- Adds `.chezmoiscripts/run_onchange_after_setup-nvim-windows.ps1.tmpl` (Windows-only)
- Creates symlink: `%LOCALAPPDATA%\nvim` → `%USERPROFILE%\.config\nvim`
- Guards against missing source directory (exits with error if `~/.config/nvim` doesn't exist)
- Idempotent: skips re-creation if the correct symlink already exists (case-insensitive, trailing-backslash-tolerant comparison)
- Warns before removing any pre-existing item at the target path
- Requires Developer Mode (same as the existing PowerShell profile symlink script)

## Test plan

- [x] Script logic reviewed for idempotency and edge cases
- [x] Run `chezmoi apply` on a fresh Windows machine and verify `%LOCALAPPDATA%\nvim` symlink is created
- [x] Verify Neovim launches and loads config correctly on Windows