### PR TITLE
chore(git): set default branch name to main

### DIFF
--- a/dot_config/git/config
+++ b/dot_config/git/config
@@ -1,6 +1,9 @@
 [core]
 	pager = delta
 
+[init]
+	defaultBranch = main
+
 [pull]
 	rebase = true
 


### PR DESCRIPTION
## Summary
Configures Git's global default branch name to `main` so that `git init` creates a `main` branch by default rather than relying on the compiled-in default.

## Details
- Adds `[init] defaultBranch = main` to the shared Git config

## Test plan
- [x] Config is well-formed and consistent with existing formatting
- [x] actionlint passes on CI workflow files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Git configuration to set "main" as the default branch name for new repository initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->