### PR TITLE
fix(nvim): lazy-load vim-better-whitespace to skip startup screen

### DIFF
--- a/dot_config/nvim/lua/plugins/ui.lua
+++ b/dot_config/nvim/lua/plugins/ui.lua
@@ -1,7 +1,7 @@
 return {
   {
     "ntpeters/vim-better-whitespace",
-    lazy = false,
+    event = { "BufReadPre", "BufNewFile" },
     config = function()
       vim.g.better_whitespace_ctermcolor = "darkred"
       vim.g.better_whitespace_guicolor = "darkred"


### PR DESCRIPTION
## Summary
`vim-better-whitespace` was set to `lazy = false`, causing it to activate on the Neovim startup screen (dashboard etc.) where it has no meaningful purpose.

## Details
- Replace `lazy = false` with `event = { "BufReadPre", "BufNewFile" }` so the plugin only loads when a real buffer is opened
- The `config` callback (setting highlight colors) still runs before whitespace highlighting is applied, so behavior in normal buffers is unchanged
- Startup screen buffers are naturally excluded since they don't trigger these events

## Test plan
- [x] Verified the lazy.nvim spec is correct and idiomatic
- [x] Open Neovim and confirm no whitespace highlighting on the startup screen
- [x] Open a file with trailing whitespace and confirm highlighting still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized plugin loading behavior to improve startup performance. The whitespace handling plugin now uses event-driven initialization, deferring setup until a buffer is read or a new file is created, reducing unnecessary resource consumption during application startup while maintaining full functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->