### PR TITLE
feat: add .gitattributes for consistent line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
## Summary
Add a `.gitattributes` file to enforce LF line endings across all files, ensuring consistent behavior across different operating systems (Linux, macOS, Windows).

## Details
- Add `* text=auto eol=lf` to normalize all text files to LF on checkout and commit

## Test plan
- [x] `.gitattributes` file created with correct content
- [ ] Verify line endings are normalized correctly after clone on Windows