### PR TITLE
feat(powershell): support machine-local profile via profile.local.ps1

### DIFF
--- a/dot_config/powershell/Microsoft.PowerShell_profile.ps1
+++ b/dot_config/powershell/Microsoft.PowerShell_profile.ps1
@@ -35,3 +35,7 @@ if ($PSVersionTable.PSVersion.Major -ge 6) {
 
 # zoxide (z and zi)
 Invoke-Expression (& { (zoxide init powershell | Out-String) })
+
+# Load machine-local settings if present
+$localProfile = Join-Path (Split-Path $PROFILE) "profile.local.ps1"
+if (Test-Path $localProfile) { . $localProfile }


### PR DESCRIPTION
## Summary
PowerShell プロファイルに `.zshrc.local` と同様のマシン固有設定の仕組みを追加します。`~/.config/powershell/profile.local.ps1` が存在する場合にメインプロファイルの末尾で読み込むようにします。

## Details
- `Microsoft.PowerShell_profile.ps1` の末尾で `profile.local.ps1` を source するブロックを追加
- `create_profile.local.ps1` を chezmoi に追加し、初回 `chezmoi apply` 時に空の `profile.local.ps1` を自動生成（既存ファイルは上書きしない）

## Test plan
- [x] プロファイルの末尾に source ブロックが追加されていることを確認
- [ ] `chezmoi apply` 後に `~/.config/powershell/profile.local.ps1` が生成されることを確認
- [ ] `profile.local.ps1` に設定を書いた場合に PowerShell 起動時に読み込まれることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PowerShell profile now automatically loads machine-specific local configuration settings on startup, enabling personalized shell environments without modifying the base profile.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pinelibg/dotfiles/pull/412?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->