### PR TITLE
fix(zsh): use valid 'c' suffix for zinit wait ice on fast-syntax-highlighting

### DIFF
--- a/dot_zsh/zinit.zsh.tmpl
+++ b/dot_zsh/zinit.zsh.tmpl
@@ -1,5 +1,5 @@
 zinit ice wait lucid blockf; zinit light zsh-users/zsh-completions
-zinit ice wait'!0z' lucid atinit"zicompinit; zicdreplay"; zinit light zdharma-continuum/fast-syntax-highlighting
+zinit ice wait'!0c' lucid atinit"zicompinit; zicdreplay"; zinit light zdharma-continuum/fast-syntax-highlighting
 
 zinit ice wait lucid atload'_zsh_autosuggest_start; bindkey "^ " autosuggest-accept'
 zinit light zsh-users/zsh-autosuggestions


### PR DESCRIPTION
## Summary

Fixes a startup warning produced by zinit when loading `fast-syntax-highlighting`: `wait ice received invalid suffix letter 'z'`. The `z` suffix is not recognized by zinit; valid ordering suffixes are `a`, `b`, `c`, or none.

## Details

- Changed `wait'!0z'` to `wait'!0c'` for `zdharma-continuum/fast-syntax-highlighting`
- The `c` suffix ensures this plugin loads last within the same wait tick (after completions and autosuggestions), which is the intended ordering
- The `!` (prompt reset) behaviour is preserved

## Test plan

- [x] No more `invalid suffix letter` warning on zsh startup
- [ ] Verify `fast-syntax-highlighting` still loads and highlights correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated shell plugin initialization configuration to optimize plugin loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->