### PR TITLE
refactor(powershell): remove default history listing in profile script

### DIFF
--- a/dot_config/powershell/Microsoft.PowerShell_profile.ps1
+++ b/dot_config/powershell/Microsoft.PowerShell_profile.ps1
@@ -12,15 +12,6 @@ $env:MISE_PWSH_CHPWD_WARNING=0 # Disable warning about changing directory for Po
 # Setup starship prompt
 Invoke-Expression (&starship init powershell)
 
-# List history by default (Toggle by F2 key)
-# Only if the -PredictionViewStyle option is available
-if (Get-Command Set-PSReadLineOption -ErrorAction SilentlyContinue) {
-    $options = Get-Command Set-PSReadLineOption | Select-Object -ExpandProperty Parameters
-    if ($options.ContainsKey('PredictionViewStyle')) {
-        Set-PSReadLineOption -PredictionViewStyle ListView
-    }
-}
-
 # Set fzf options
 $env:FZF_DEFAULT_OPTS="--height 50% --layout=reverse"
 


### PR DESCRIPTION
## Summary
Removes the PSReadLine `PredictionViewStyle ListView` configuration block from the PowerShell profile script, which was responsible for enabling list-view history prediction by default.

## Details
- Removed the `Set-PSReadLineOption -PredictionViewStyle ListView` block and its availability guard from `dot_config/powershell/Microsoft.PowerShell_profile.ps1`

## Test plan
- [x] Verified profile script loads without errors
- [ ] Confirm PowerShell starts without the list-view history prediction (default behavior restored)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed PowerShell ReadLine prediction view style configuration. This setting previously controlled the history listing display behavior that could be toggled via the F2 key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->