### PR TITLE
feat(mise): add shim mode switch via ~/.mise_shim

### DIFF
--- a/.chezmoitemplates/shell_setup_mise
+++ b/.chezmoitemplates/shell_setup_mise
@@ -10,7 +10,11 @@ else
 {{- if eq .os "windows" }}
 		export PATH="${LOCALAPPDATA}/mise/shims:${PATH}"
 {{- else }}
-		eval "$(mise activate {{ .shell }})"
+		if [[ -f ~/.mise_shim ]]; then
+			eval "$(mise activate --shims {{ .shell }})"
+		else
+			eval "$(mise activate {{ .shell }})"
+		fi
 {{- end }}
 	fi
 fi


### PR DESCRIPTION
## Summary

Adds a runtime toggle to switch mise shell integration from hook-based activation to shim mode on non-Windows systems, without requiring `chezmoi apply` to be re-run.

## Details

- When `~/.mise_shim` exists, `shell_setup_mise` calls `mise activate --shims <shell>` instead of `mise activate <shell>`
- Windows is unchanged (always PATH-based shims via `%LOCALAPPDATA%/mise/shims`)
- Follows the existing file-flag pattern used by `~/.no_mise`

## Test plan

- [x] Template renders correctly for both shim and non-shim cases
- [ ] Verify `mise activate --shims zsh` works as expected with `~/.mise_shim` present
- [ ] Verify default activation is unchanged when `~/.mise_shim` is absent