### PR TITLE
chore(starship): remove python prompt module

### DIFF
--- a/dot_config/starship.toml
+++ b/dot_config/starship.toml
@@ -15,7 +15,6 @@ $git_state\
 $git_status\
 $cmd_duration\
 $line_break\
-$python\
 $character"""
 
 [directory]
@@ -49,6 +48,3 @@ style = "bright-black"
 format = "[$duration]($style) "
 style = "yellow"
 
-[python]
-format = "[$virtualenv]($style) "
-style = "bright-black"


### PR DESCRIPTION
## Summary
Remove the Python virtualenv segment from the Starship prompt.

## Details
- Drop `$python\` from the prompt `format` string
- Remove the `[python]` section (format and style)

## Test plan
- [x] Verified the resulting `starship.toml` is valid TOML with no dangling references to the removed module

## Notes (optional)
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified the command-line prompt by removing the Python virtual-environment indicator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->